### PR TITLE
Fixed get_existing_indices

### DIFF
--- a/goblin/spec.py
+++ b/goblin/spec.py
@@ -7,8 +7,8 @@ from goblin import connection
 
 def get_existing_indices():
     """ Find all Vertex and Edge types available in the database """
-    vertex_indices = connection.execute_query('g.getIndexedKeys(Vertex.class)')
-    edge_indices = connection.execute_query('g.getIndexedKeys(Edge.class)')
+    vertex_indices = connection.execute_query('mgmt = graph.openManagement(); mgmt.getVertexLabels().collect{it.name()}')
+    edge_indices = connection.execute_query('mgmt = graph.openManagement(); mgmt.getRelationTypes(EdgeLabel).collect{it.name()}')
     return vertex_indices, edge_indices
 
 

--- a/goblin/tests/spec_tests.py
+++ b/goblin/tests/spec_tests.py
@@ -67,8 +67,8 @@ class TestSpecSystem(BaseGoblinTestCase):
         v_idx, e_idx = get_existing_indices()
         v_idx = (yield (yield v_idx).read()).data
         e_idx = (yield (yield e_idx).read()).data
-        # self.assertEqual(len(v_idx), 0)
-        # self.assertEqual(len(e_idx), 0)
+        self.assertEqual(len(v_idx), 0)
+        self.assertEqual(len(e_idx), 0)
 
         # create vertex and edge index
         yield connection.execute_query('mgmt = graph.openManagement(); mgmt.makeVertexLabel(name).make(); mgmt.commit()',
@@ -78,7 +78,5 @@ class TestSpecSystem(BaseGoblinTestCase):
         v_idx, e_idx = get_existing_indices()
         v_idx = (yield (yield v_idx).read()).data
         e_idx = (yield (yield e_idx).read()).data
-        print(v_idx)
-        print(e_idx)
         self.assertEqual(len(v_idx), 1)
         self.assertEqual(len(e_idx), 1)

--- a/goblin/tests/spec_tests.py
+++ b/goblin/tests/spec_tests.py
@@ -5,6 +5,10 @@ from nose.plugins.attrib import attr
 from nose.tools import nottest
 
 
+from tornado import gen
+from tornado.ioloop import IOLoop
+from tornado.testing import gen_test
+
 from .base import BaseGoblinTestCase
 from goblin import connection
 from goblin.models import Vertex, Edge
@@ -57,18 +61,24 @@ class TestSpecSystem(BaseGoblinTestCase):
                 self.assertDictContainsKeyWithValueType(
                     pv['compiled'], 'transaction', bool)
 
-    @nottest
+    @gen_test
     def test_gather_existing_indices(self):
-        """ Make sure existing indices can be gathered """
+        """ Make sure existing vertex and edge types can be gathered """
         v_idx, e_idx = get_existing_indices()
-        self.assertEqual(len(v_idx), 0)
-        self.assertEqual(len(e_idx), 0)
+        v_idx = (yield (yield v_idx).read()).data
+        e_idx = (yield (yield e_idx).read()).data
+        # self.assertEqual(len(v_idx), 0)
+        # self.assertEqual(len(e_idx), 0)
 
         # create vertex and edge index
-        connection.execute_query('g.makeKey(name).dataType(Object.class).indexed(Vertex.class).make(); g.commit()',
+        yield connection.execute_query('mgmt = graph.openManagement(); mgmt.makeVertexLabel(name).make(); mgmt.commit()',
                                  params={'name': 'testvertexindex'})
-        connection.execute_query('g.makeLabel(name).dataType(Object.class).indexed(Edge.class).make(); g.commit()',
+        yield connection.execute_query('mgmt = graph.openManagement(); mgmt.makeEdgeLabel(name).make(); mgmt.commit()',
                                  params={'name': 'testedgeindex'})
         v_idx, e_idx = get_existing_indices()
+        v_idx = (yield (yield v_idx).read()).data
+        e_idx = (yield (yield e_idx).read()).data
+        print(v_idx)
+        print(e_idx)
         self.assertEqual(len(v_idx), 1)
         self.assertEqual(len(e_idx), 1)


### PR DESCRIPTION
index management moved to com.thinkaurelius.titan.graphdb.database.management.ManagementSystem. Any index management, setting of cardinality constraints, property key defs,etc need to go through the aforementioned class.
