### PR TITLE
Added ability to add custom label formatting for derived classes

### DIFF
--- a/goblin/models/edge.py
+++ b/goblin/models/edge.py
@@ -18,7 +18,7 @@ class EdgeMetaClass(ElementMetaClass):
 
     def __new__(mcs, name, bases, body):
         # short circuit element_type inheritance
-        body['label'] = body.pop('label', None)
+        body['_label'] = body.pop('_label', None)
 
         klass = super(EdgeMetaClass, mcs).__new__(mcs, name, bases, body)
 
@@ -35,7 +35,7 @@ class EdgeMetaClass(ElementMetaClass):
                            bases: %s
                            body: %s""" % (label, mcs, name, bases, body)))
             else:
-                edge_types[klass.get_label()] = klass
+                edge_types[label] = klass
         return klass
 
 
@@ -50,7 +50,7 @@ class Edge(Element):
     # be created between two vertices
     __exclusive__ = False
 
-    label = None
+    _label = None
 
     gremlin_path = 'edge.groovy'
 
@@ -199,7 +199,7 @@ class Edge(Element):
         :rtype: str
 
         """
-        return cls._type_name(cls.label)
+        return cls._type_name(cls._label)
 
     @classmethod
     def get_between(cls, outV, inV, page_num=None, per_page=None):

--- a/goblin/models/element.py
+++ b/goblin/models/element.py
@@ -119,7 +119,7 @@ class BaseElement(object):
         return not self.__eq__(other)  # pragma: no cover
 
     @classmethod
-    def _type_name_formatter(cls, type_name):
+    def format_type_name(cls, type_name):
         """
         Specifies the format that should be used to format the type_name
 
@@ -145,7 +145,7 @@ class BaseElement(object):
 
         """
         pf_name = manual_name if manual_name else cls.__name__
-        pf_name = cls._type_name_formatter(pf_name)
+        pf_name = cls.format_type_name(pf_name)
         return pf_name.lstrip('_')
 
     def validate_field(self, field_name, val):

--- a/goblin/models/element.py
+++ b/goblin/models/element.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import logging
 import re
 import warnings
+import inflection
 from collections import OrderedDict
 
 from goblin import connection
@@ -118,7 +119,22 @@ class BaseElement(object):
         return not self.__eq__(other)  # pragma: no cover
 
     @classmethod
-    def _type_name(cls, manual_name):
+    def _type_name_formatter(cls, type_name):
+        """
+        Specifies the format that should be used to format the type_name
+
+        By default it will force lower case snake_case formatting. It may
+        be overriden in a derived class
+
+        :param type_name: The name to format
+        :type type_name: str
+        :rtype: str
+        """
+        return inflection.underscore(type_name).lower()
+
+
+    @classmethod
+    def _type_name(cls, manual_name=None):
         """
         Returns the element name if it has been defined, otherwise it creates
         it from the module and class name.
@@ -128,16 +144,8 @@ class BaseElement(object):
         :rtype: str
 
         """
-        pf_name = ''
-        if manual_name:
-            pf_name = manual_name.lower()
-        else:
-            camelcase = re.compile(r'([a-z])([A-Z])')
-            ccase = lambda s: camelcase.sub(lambda v: '{}_{}'.format(
-                v.group(1), v.group(2).lower()), s)
-
-            pf_name += ccase(cls.__name__)
-            pf_name = pf_name.lower()
+        pf_name = manual_name if manual_name else cls.__name__
+        pf_name = cls._type_name_formatter(pf_name)
         return pf_name.lstrip('_')
 
     def validate_field(self, field_name, val):

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ virtualenv==14.0.6
 watchdog==0.8.3
 wheel==0.24.0
 zope.interface==4.1.3
+inflection==0.3.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ develop_requires = ['Sphinx==1.3.5',
                     'sphinx-rtd-theme==0.1.9',
                     'tox==2.3.1',
                     'Twisted==15.5.0',
-                    'watchdog==0.8.3']
+                    'watchdog==0.8.3',
+                    'inflection==0.3.1']
 
 long_desc = """
 Object-Graph Mapper (OGM) for the TinkerPop 3 Gremlin Server
@@ -61,6 +62,7 @@ setup(
                       'pytz>=2015.7',
                       'gremlinclient>=0.2.6',
                       'six>=1.10.0',
+                      'inflection==0.3.1',
                       'factory-boy>=2.6.0'],
     extras_require={
         'develop': develop_requires,


### PR DESCRIPTION
  By adding a formatting method to the Element class, a derived class
  can provide its own formatting function. Examples:

```
from goblin.models import Vertex, Edge
import inflection

class CustomVertex(Vertex):

    @classmethod
    def _type_name_formatter(cls, type_name):
        return inflection.camelize(type_name)

class CustomEdge(Edge):

    @classmethod
    def _type_name_formatter(cls, type_name):
        return inflection.underscore(type_name).upper()
```

  Also fixed problem with getting label from Edge classes
