### PR TITLE
GroovyFunctionParser - functions with no arguments

### DIFF
--- a/goblin/gremlin/groovy.py
+++ b/goblin/gremlin/groovy.py
@@ -21,6 +21,7 @@ class GroovyFunctionParser(object):
     VarName = pyparsing.Regex(r'[A-Za-z_]\w*')
     FuncName = VarName
     FuncDefn = KeywordDef + FuncName + "(" + pyparsing.delimitedList(VarName) + ")" + "{"
+    FuncDefnNoArgs = KeywordDef + FuncName + "(" + ")" + "{"
 
     @classmethod
     def parse(cls, data):
@@ -34,7 +35,10 @@ class GroovyFunctionParser(object):
         """
         try:
             # Parse the function here
-            result = cls.FuncDefn.parseString(data)
+            try:
+                result = cls.FuncDefn.parseString(data)
+            except Exception as ex:
+                result = cls.FuncDefnNoArgs.parseString(data)
             result_list = result.asList()
             args = result_list[3:result_list.index(')')]
             # Return single line or multi-line function body

--- a/goblin/gremlin/groovy.py
+++ b/goblin/gremlin/groovy.py
@@ -20,7 +20,7 @@ class GroovyFunctionParser(object):
     KeywordDef = pyparsing.Keyword('def')
     VarName = pyparsing.Regex(r'[A-Za-z_]\w*')
     FuncName = VarName
-    FuncDefn = KeywordDef + FuncName + "(" + pyparsing.delimitedList(VarName) + ")" + "{"
+    FuncDefn = KeywordDef + FuncName + "(" + pyparsing.Optional(pyparsing.delimitedList(VarName)) + ")" + "{"
     FuncDefnNoArgs = KeywordDef + FuncName + "(" + ")" + "{"
 
     @classmethod
@@ -35,10 +35,7 @@ class GroovyFunctionParser(object):
         """
         try:
             # Parse the function here
-            try:
-                result = cls.FuncDefn.parseString(data)
-            except Exception as ex:
-                result = cls.FuncDefnNoArgs.parseString(data)
+            result = cls.FuncDefn.parseString(data)
             result_list = result.asList()
             args = result_list[3:result_list.index(')')]
             # Return single line or multi-line function body

--- a/goblin/tests/groovy_tests/scanner_tests.py
+++ b/goblin/tests/groovy_tests/scanner_tests.py
@@ -58,6 +58,14 @@ class GroovyScannerTest(BaseGoblinTestCase):
         self.assertEqual(result.body, 'def n = null;\n    for (i in x) {\n n=i; \n}')
         self.assertEqual(result.defn, test_func)
 
+    def test_parsing_example_noargs_function(self):
+        test_func = 'def test_noargs_func() {\n    def n = null;\n    for (i in x) {\n n=i; \n}\n}\n'
+        result = GroovyFunctionParser.parse(test_func)
+        self.assertEqual(result.name, 'test_noargs_func')
+        self.assertListEqual(result.args, [])
+        self.assertEqual(result.body, 'def n = null;\n    for (i in x) {\n n=i; \n}')
+        self.assertEqual(result.defn, test_func)
+
     def test_parsing_example_import(self):
         test_import = 'import com.wellaware.test; //this is sample text'
         result = GroovyImportParser.parse(test_import)


### PR DESCRIPTION
This should fix GroovyFunctionParser's handling of functions with no arguments (I do a lot of graph-wide manipulations periodically, hence the lack of arguments).
