### PR TITLE
Added support for the equal operator

### DIFF
--- a/goblin/models/element.py
+++ b/goblin/models/element.py
@@ -94,30 +94,6 @@ class BaseElement(object):
     def id(self, id):
         self._id = id
 
-    def __eq__(self, other):
-        """
-        Check for equality between two elements.
-
-        :param other: Element to be compared to
-        :type other: BaseElement
-        :rtype: boolean
-
-        """
-        if not isinstance(other, BaseElement):  # pragma: no cover
-            return False
-        return self.as_dict() == other.as_dict()
-
-    def __ne__(self, other):
-        """
-        Check for inequality between two elements.
-
-        :param other: Element to be compared to
-        :type other: BaseElement
-        :rtype: boolean
-
-        """
-        return not self.__eq__(other)  # pragma: no cover
-
     @classmethod
     def format_type_name(cls, type_name):
         """
@@ -535,6 +511,18 @@ class BaseElement(object):
             yield item
 
     def __eq__(self, other):
+        """
+        Check for equality between two elements.
+
+        :param other: Element to be compared to
+        :type other: BaseElement
+        :rtype: boolean
+
+        """
+        if self.__class__ != other.__class__:
+            return False
+        if self.id is None:
+            return self is other
         return self.id == other.id
 
     def items(self):

--- a/goblin/models/element.py
+++ b/goblin/models/element.py
@@ -534,6 +534,9 @@ class BaseElement(object):
                 set(self._manual_values.keys())):
             yield item
 
+    def __eq__(self, other):
+        return self.id == other.id
+
     def items(self):
         items = []
         for key in self._properties.keys():

--- a/goblin/tests/models_tests/edge_io_tests.py
+++ b/goblin/tests/models_tests/edge_io_tests.py
@@ -285,3 +285,20 @@ class TestEdgeIO(BaseGoblinTestCase):
             yield e1.delete()
             yield v1.delete()
             yield v2.delete()
+
+    @gen_test
+    def test___eq__operator(self):
+        v1 = yield TestVertexModel.create(test_val=8, name='a')
+        v2 = yield TestVertexModel.create(test_val=7, name='b')
+        e1 = yield TestEdgeModel.create(v1, v2, test_val=-99, name='e1')
+
+        try:
+            stream = yield TestEdgeModel.find_by_value('test_val', -99)
+            results = yield stream.read()
+            self.assertEqual(len(results), 1)
+            e2 = results[0]
+            self.assertEqual(e1, e2)
+        finally:
+            yield e1.delete()
+            yield v1.delete()
+            yield v2.delete()

--- a/goblin/tests/models_tests/vertex_io_tests.py
+++ b/goblin/tests/models_tests/vertex_io_tests.py
@@ -798,3 +798,16 @@ class TestVertexTraversal(BaseGoblinTestCase):
                 print_("Got value: {}".format(value))
         finally:
             yield v.delete()
+
+    @gen_test
+    def test___eq__operator(self):
+        v1 = yield TestVertexModel.create(test_val=8, name='a')
+
+        try:
+            stream = yield TestVertexModel.find_by_value('test_val', 8)
+            results = yield stream.read()
+            self.assertEqual(len(results), 1)
+            v2 = results[0]
+            self.assertEqual(v1, v2)
+        finally:
+            yield v1.delete()

--- a/goblin/tests/models_tests/vertex_io_tests.py
+++ b/goblin/tests/models_tests/vertex_io_tests.py
@@ -802,12 +802,35 @@ class TestVertexTraversal(BaseGoblinTestCase):
     @gen_test
     def test___eq__operator(self):
         v1 = yield TestVertexModel.create(test_val=8, name='a')
-
         try:
             stream = yield TestVertexModel.find_by_value('test_val', 8)
             results = yield stream.read()
             self.assertEqual(len(results), 1)
             v2 = results[0]
-            self.assertEqual(v1, v2)
+            self.assertTrue(v1 == v2)
         finally:
             yield v1.delete()
+
+        v1 = TestVertexModel(test_val=8, name='a')
+        self.assertIsNone(v1.id)
+        v2 = v1
+        v3 = 'TestVertexModel'
+        self.assertTrue(v1 == v2)
+        self.assertTrue(v1 != v3)
+
+        v1 = TestVertexModel(test_val=8, name='a')
+        v2 = TestVertexModel(test_val=8, name='a')
+        self.assertTrue(v1 != v2)
+
+        v1 = yield TestVertexModel.create(test_val=8, name='a', extra_prop=1)
+        v3 = yield TestVertexModel.create(test_val=8, name='a', extra_prop=2)
+        try:
+            stream = yield TestVertexModel.find_by_value('extra_prop', 1)
+            results = yield stream.read()
+            self.assertEqual(len(results), 1)
+            v2 = results[0]
+            self.assertTrue(v1 == v2)
+            self.assertTrue(v1 != v3)
+        finally:
+            yield v1.delete()
+            yield v3.delete()


### PR DESCRIPTION
  This allows edges and vertices to be compared. This is especially
  useful in unit testing so that one can verify that a edge or vertex
  retrieved from the database is the same as an existing instance
