### PR TITLE
add vagrant file to start a development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,22 @@ A good `pull` request should:
   commits into one)
 * Make sure all tests pass
 
+# Using vagrant environment
+
+You can use [vagrant](https://www.vagrantup.com/) to start a development environment with cassandra, elasticsearch and titan. It uses docker for running the necessary services.
+
+Start the environment with:
+
+```
+$ vagrant up
+```
+
+Run the integrated tests with:
+
+```
+$ vagrant ssh -c 'cd /vagrant; ./run_tests.sh'
+```
+
 # Integration with Python Asynchronous Frameworks
 
 `goblin` is designed to interact smoothly with a variety of async frameworks such as [aiohttp](http://aiohttp.readthedocs.org/en/stable/), [Tornado](http://www.tornadoweb.org/en/stable/), and [Pulsar](http://pythonhosted.org/pulsar/). The following examples demonstrate some simple integration with Pulsar using the `gremlinclinet.aiohttp` module.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,84 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "williamyeh/ubuntu-trusty64-docker"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network "forwarded_port", guest: 3080, host: 3080
+  # google/cadvisor webui
+  config.vm.network "forwarded_port", guest: 8080, host: 3081
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo docker pull elasticsearch
+    sudo docker pull elubow/cassandra
+    sudo docker pull davebshow/titan-websockets
+    which add-apt-repository >/dev/null || sudo apt-get install -y software-properties-common
+    if [ ! -e /etc/apt/sources.list.d/fkrull-deadsnakes-trusty.list ]; then sudo add-apt-repository ppa:fkrull/deadsnakes && sudo apt-get update; fi
+    (which python3.5 >/dev/null && which pip3 > /dev/null && false) || sudo apt-get install -y python3.5 python3-pip python3.5-venv libpython3.5-dev
+    sudo rm /usr/bin/python3 && sudo ln -s python3.5 /usr/bin/python3
+    cd /vagrant
+    sudo apt-get install -y libyaml-dev
+    sudo pip3 install -r requirements.txt
+    sudo docker start es1 || sudo docker run -d  --restart=always --name es1 elasticsearch
+    sudo docker start cas1 || sudo docker run -d  --restart=always --name cas1 elubow/cassandra
+    sudo docker start titan1 || sudo docker run -d --name titan1 --restart=always  --link es1:elasticsearch --link cas1:cassandra -p 8182:8182 davebshow/titan-websockets
+  SHELL
+end


### PR DESCRIPTION
makes it easy to get a running goblin environment.

it uses the cassandra, elasticsearch and titan docker images for
data storage.
Have not tested it outside of the default virtualbox environment.
