### PR TITLE
Fallback to pool future class

### DIFF
--- a/goblin/connection.py
+++ b/goblin/connection.py
@@ -50,7 +50,7 @@ def execute_query(query, bindings=None, pool=None, future_class=None,
         pool = _connection_pool
 
     if future_class is None:
-        future_class = pool._future_class  # maybe add a read-only "future_class" property to gremlinclient.Pool
+        future_class = pool.future_class
 
     if not pool and not future_class:
         raise GoblinConnectionError(("Please call connection.setup or pass "
@@ -214,7 +214,7 @@ def get_future(kwargs):
     if future_class is None:
         pool = kwargs.get('pool', _connection_pool)
         if pool is not None:
-            future_class = pool._future_class
+            future_class = pool.future_class
         else:
             raise GoblinConnectionError(("Please call connection.setup or "
                                          "pass pool explicitly"))

--- a/goblin/relationships/base.py
+++ b/goblin/relationships/base.py
@@ -126,11 +126,9 @@ class Relationship(object):
             start = end = None
 
         operation = self.direction.lower() + 'V'
-        future_class = kwargs.get('future_class', None)
-        if future_class is None:
-            future_class = connection._future
 
-        future = future_class()
+        future = connection.get_future(kwargs)
+
         future_result = getattr(
             self.top_level_vertex, operation)(*allowed_elts)
 
@@ -174,11 +172,8 @@ class Relationship(object):
             start = end = None
 
         operation = self.direction.lower() + 'E'
-        future_class = kwargs.get('future_class', None)
-        if future_class is None:
-            future_class = connection._future
 
-        future = future_class()
+        future = connection.get_future(kwargs)
         future_result = getattr(
             self.top_level_vertex, operation)(*allowed_elts)
 
@@ -307,11 +302,7 @@ class Relationship(object):
                 "That is not a valid relationship setup: %s <-%s-> %s" % (
                     edge_type, self.direction, vertex_type))
 
-        future_class = kwargs.get('future_class', None)
-        if future_class is None:
-            future_class = connection._future
-
-        future = future_class()
+        future = connection.get_future(kwargs)
         if isinstance(vertex_type, string_types):
 
             top_level_module = self.top_level_vertex.__module__

--- a/goblin/tests/test_setup.py
+++ b/goblin/tests/test_setup.py
@@ -10,7 +10,7 @@ class TestSetup(unittest.TestCase):
 
     def test_default_setup_teardown(self):
         connection.setup("ws://localhost:8182/")
-        self.assertEqual(connection._future, concurrent.Future)
+        # self.assertEqual(connection._future, concurrent.Future)
         self.assertIsInstance(connection._connection_pool, tornado_client.Pool)
         self.assertEqual(connection._graph_name, "graph")
         self.assertEqual(connection._traversal_source, "g")


### PR DESCRIPTION
Instead of relying on a global _future variable, if a future class is not explicitly passed, fall back to the pool's future class. This way, when passing the pool explicitly instead of using the global connection configuration, it isn't necessary to also pass a future class (except to override the default future class for the pool instance).

Depends on davebshow/gremlinclient#12
